### PR TITLE
chore(deps): bump NuGet packages and release v1.0.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
     <Import Project="releasenotes.props" />
 
     <PropertyGroup>
-        <VersionPrefix>1.0.0</VersionPrefix>
+        <VersionPrefix>1.0.1</VersionPrefix>
         <!-- SPDX license identifier for MIT -->
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
 

--- a/src/LayeredCraft.DecoWeaver.Generators/LayeredCraft.DecoWeaver.Generators.csproj
+++ b/src/LayeredCraft.DecoWeaver.Generators/LayeredCraft.DecoWeaver.Generators.csproj
@@ -25,7 +25,7 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Scriban" Version="7.0.5" IncludeAssets="build" PrivateAssets="all" />
+        <PackageReference Include="Scriban" Version="7.0.6" IncludeAssets="build" PrivateAssets="all" />
         <ProjectReference Include="..\LayeredCraft.DecoWeaver.Attributes\LayeredCraft.DecoWeaver.Attributes.csproj" PrivateAssets="All" />
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.201">
           <PrivateAssets>all</PrivateAssets>
@@ -54,15 +54,5 @@
     </ItemGroup>
     <ItemGroup>
       <Folder Include="Roslyn\" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <!-- Scriban 7 source include already provides these AOT/trimming attributes.
-             Remove Polyfill's copies to avoid duplicate type definitions. -->
-        <Compile Remove="$(NuGetPackageRoot)polyfill\9.23.0\contentFiles\cs\netstandard2.0\Trimming\DynamicallyAccessedMembersAttribute.cs" />
-        <Compile Remove="$(NuGetPackageRoot)polyfill\9.23.0\contentFiles\cs\netstandard2.0\Trimming\DynamicallyAccessedMemberTypes.cs" />
-        <Compile Remove="$(NuGetPackageRoot)polyfill\9.23.0\contentFiles\cs\netstandard2.0\Trimming\RequiresDynamicCodeAttribute.cs" />
-        <Compile Remove="$(NuGetPackageRoot)polyfill\9.23.0\contentFiles\cs\netstandard2.0\Trimming\RequiresUnreferencedCodeAttribute.cs" />
-        <Compile Remove="$(NuGetPackageRoot)polyfill\9.23.0\contentFiles\cs\netstandard2.0\Trimming\UnconditionalSuppressMessageAttribute.cs" />
     </ItemGroup>
 </Project>

--- a/test/LayeredCraft.DecoWeaver.Generator.Tests/LayeredCraft.DecoWeaver.Generator.Tests.csproj
+++ b/test/LayeredCraft.DecoWeaver.Generator.Tests/LayeredCraft.DecoWeaver.Generator.Tests.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
     <PackageReference Include="AutoFixture.Xunit3" Version="4.19.0" />
     <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="Verify.SourceGenerators" Version="2.5.0" />


### PR DESCRIPTION
## Summary

Bumps three NuGet dependencies and increments the version to `1.0.1`. The Scriban upgrade from `7.0.5` to `7.0.6` resolves duplicate trimming-attribute type definitions that previously required explicit `<Compile Remove>` workarounds in the generator project — those workarounds are now removed. The `Microsoft.CodeAnalysis.CSharp` test reference is also updated to `5.3.0`.

## Changes

- `Directory.Build.props`: `VersionPrefix` `1.0.0` → `1.0.1`
- `LayeredCraft.DecoWeaver.Generators.csproj`: `Scriban` `7.0.5` → `7.0.6`; removed five `<Compile Remove>` items for Polyfill trimming attributes (no longer needed — Scriban 7.0.6 no longer conflicts)
- `LayeredCraft.DecoWeaver.Generator.Tests.csproj`: `Microsoft.CodeAnalysis.CSharp` `5.0.0` → `5.3.0`

## Validation

- `dotnet build` succeeds with no warnings or errors
- Polyfill trimming attribute workarounds verified no longer needed after Scriban bump

## Release Notes

`v1.0.1` — dependency maintenance release. No API or behavioral changes.