### PR TITLE
ci: upgrade devops-templates to v10.0 with NuGet trusted publishing

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -7,7 +7,7 @@ on:
 permissions: write-all
 jobs:
   build:
-    uses: LayeredCraft/devops-templates/.github/workflows/pr-build.yaml@v8.0
+    uses: LayeredCraft/devops-templates/.github/workflows/pr-build.yaml@v10.0
     with:
       solution: LayeredCraft.DecoWeaver.slnx
       hasTests: true

--- a/.github/workflows/pr-title-check.yaml
+++ b/.github/workflows/pr-title-check.yaml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   validate:
-    uses: LayeredCraft/devops-templates/.github/workflows/pr-title-check.yml@v8.0
+    uses: LayeredCraft/devops-templates/.github/workflows/pr-title-check.yml@v10.0

--- a/.github/workflows/publish-preview.yaml
+++ b/.github/workflows/publish-preview.yaml
@@ -8,11 +8,13 @@ on:
       - 'docs/**'
       - 'README.md'
 
-permissions: write-all
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
-  publish:
-    uses: LayeredCraft/devops-templates/.github/workflows/publish-preview.yml@v8.0
+  build:
+    uses: LayeredCraft/devops-templates/.github/workflows/publish-preview.yml@v10.0
     with:
       solution: LayeredCraft.DecoWeaver.slnx
       dotnetVersion: |
@@ -22,3 +24,14 @@ jobs:
         11.0.x
       hasTests: true
     secrets: inherit
+
+  push:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: LayeredCraft/devops-templates/.github/actions/nuget-push@v10.0
+        with:
+          nuget_user: ${{ secrets.NUGET_USER }}

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -4,11 +4,12 @@ on:
   release:
     types: [published]
 
-permissions: write-all
+permissions:
+  contents: write
 
 jobs:
-  publish:
-    uses: LayeredCraft/devops-templates/.github/workflows/publish-release.yml@v8.0
+  build:
+    uses: LayeredCraft/devops-templates/.github/workflows/publish-release.yml@v10.0
     with:
       solution: LayeredCraft.DecoWeaver.slnx
       dotnetVersion: |
@@ -18,3 +19,14 @@ jobs:
         11.0.x
       hasTests: true
     secrets: inherit
+
+  push:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: LayeredCraft/devops-templates/.github/actions/nuget-push@v10.0
+        with:
+          nuget_user: ${{ secrets.NUGET_USER }}

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   draft:
-    uses: LayeredCraft/devops-templates/.github/workflows/release-drafter.yml@v8.0
+    uses: LayeredCraft/devops-templates/.github/workflows/release-drafter.yml@v10.0
     with:
       event_name: ${{ github.event_name }}
       pr_draft: ${{ github.event.pull_request.draft == true }}

--- a/samples/DecoWeaver.Sample/DecoWeaver.Sample.csproj
+++ b/samples/DecoWeaver.Sample/DecoWeaver.Sample.csproj
@@ -17,9 +17,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" />
-      <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.6" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.6" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+      <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
       <PackageReference Remove="Microsoft.SourceLink.GitHub" />
     </ItemGroup>
     <!-- Only write generated files to disk in Debug builds (nice for inspection) -->

--- a/src/LayeredCraft.DecoWeaver.Generators/LayeredCraft.DecoWeaver.Generators.csproj
+++ b/src/LayeredCraft.DecoWeaver.Generators/LayeredCraft.DecoWeaver.Generators.csproj
@@ -21,13 +21,13 @@
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" PrivateAssets="all" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="all" />
         <PackageReference Include="Microsoft.CSharp" Version="4.7.0" PrivateAssets="all" />
-        <PackageReference Include="Polyfill" Version="10.3.0">
+        <PackageReference Include="Polyfill" Version="10.11.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Scriban" Version="7.1.0" IncludeAssets="build" PrivateAssets="all" />
+        <PackageReference Include="Scriban" Version="7.2.5" IncludeAssets="build" PrivateAssets="all" />
         <ProjectReference Include="..\LayeredCraft.DecoWeaver.Attributes\LayeredCraft.DecoWeaver.Attributes.csproj" PrivateAssets="All" />
-        <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.202">
+        <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.300">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/test/LayeredCraft.DecoWeaver.Generator.Tests/LayeredCraft.DecoWeaver.Generator.Tests.csproj
+++ b/test/LayeredCraft.DecoWeaver.Generator.Tests/LayeredCraft.DecoWeaver.Generator.Tests.csproj
@@ -30,10 +30,10 @@
     <PackageReference Include="AutoFixture.Xunit3" Version="4.19.0" />
     <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="Verify.SourceGenerators" Version="2.5.0" />
-    <PackageReference Include="Verify.XunitV3" Version="31.16.1" />
+    <PackageReference Include="Verify.XunitV3" Version="31.20.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.202">
@@ -47,23 +47,23 @@
     <ProjectReference Include="..\..\src\LayeredCraft.DecoWeaver.Generators\LayeredCraft.DecoWeaver.Generators.csproj" />
   </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)'=='net8.0'">
-        <PackageReference Include="Basic.Reference.Assemblies.Net80" Version="1.8.5" />
+        <PackageReference Include="Basic.Reference.Assemblies.Net80" Version="1.8.9" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)'=='net9.0'">
-        <PackageReference Include="Basic.Reference.Assemblies.Net90" Version="1.8.5" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.15" />
+        <PackageReference Include="Basic.Reference.Assemblies.Net90" Version="1.8.9" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.17" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)'=='net10.0'">
-        <PackageReference Include="Basic.Reference.Assemblies.Net100" Version="1.8.5" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" />
+        <PackageReference Include="Basic.Reference.Assemblies.Net100" Version="1.8.9" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)'=='net11.0'">
-        <PackageReference Include="Basic.Reference.Assemblies.Net110" Version="1.8.5" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="11.0.0-preview.3.26207.106" />
+        <PackageReference Include="Basic.Reference.Assemblies.Net110" Version="1.8.9" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="11.0.0-preview.5.26302.115" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary

Upgrades all `devops-templates` references from `v8.0` to `v10.0` and converts the publish flows to use NuGet Trusted Publishing (OIDC) via the `nuget-push` composite action. Also includes pending package updates across sample, src, and test projects.

## Changes

**`publish-preview.yaml` and `publish-release.yaml`** — structural change
- Renamed `publish` job to `build`; shared template now handles build/test/pack/artifact upload only
- Added `push` job using `nuget-push@v10.0` composite action for OIDC login and NuGet push
- Tightened `permissions: write-all` to least-privilege per job

**`pr-build.yaml`, `pr-title-check.yaml`, `release-drafter.yaml`** — version bump only
- `@v8.0` → `@v10.0`, no other changes

**`samples/`, `src/`, `test/`** — package updates

## Validation

The `build` + `push` job pattern was validated end-to-end on `LayeredCraft/compact-json-formatter` with the same template version and composite action before applying here.

## Notes for Reviewers

NuGet.org trusted publisher entries for this repo will need to be configured pointing at `.github/workflows/publish-preview.yaml` and `.github/workflows/publish-release.yaml` before the push jobs will succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)