### PR TITLE
ci(github): fix release-drafter config to match org standard

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,71 +1,94 @@
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
-categories:
-  - title: '🚀 Features'
-    labels:
-      - 'feat'
-      - 'feature'
-  - title: '🐛 Bug Fixes'
-    labels:
-      - 'fix'
-      - 'bug'
-  - title: '🧹 Maintenance'
-    labels:
-      - 'chore'
-      - 'refactor'
-      - 'deps'
-  - title: '📖 Documentation'
-    labels:
-      - 'docs'
-      - 'documentation'
-  - title: '🔧 CI/CD'
-    labels:
-      - 'ci'
-      - 'build'
-autolabeler:
-  - label: 'feat'
-    title:
-      - '/^feat(\(.+\))?:/i'
-  - label: 'fix'
-    title:
-      - '/^fix(\(.+\))?:/i'
-  - label: 'docs'
-    title:
-      - '/^docs(\(.+\))?:/i'
-  - label: 'chore'
-    title:
-      - '/^chore(\(.+\))?:/i'
-  - label: 'refactor'
-    title:
-      - '/^refactor(\(.+\))?:/i'
-  - label: 'ci'
-    title:
-      - '/^ci(\(.+\))?:/i'
-  - label: 'deps'
-    title:
-      - '/^(chore|build)(\(deps\))?:/i'
-change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
-change-title-escapes: '\<*_&'
+commitish: main
+
 version-resolver:
   major:
     labels:
-      - 'breaking'
-      - 'major'
+      - 'breaking-change'
   minor:
     labels:
-      - 'feat'
-      - 'feature'
+      - 'type: feat'
   patch:
     labels:
-      - 'fix'
-      - 'bug'
-      - 'chore'
-      - 'refactor'
-      - 'deps'
-      - 'docs'
-      - 'ci'
-      - 'build'
+      - 'type: fix'
+      - 'type: docs'
+      - 'type: refactor'
+      - 'type: test'
+      - 'type: chore'
+      - 'type: ci'
+      - 'type: revert'
   default: patch
+
+autolabeler:
+  - label: 'type: feat'
+    title:
+      - '/^feat(\(.+\))?(!)?:/i'
+  - label: 'type: fix'
+    title:
+      - '/^fix(\(.+\))?(!)?:/i'
+  - label: 'type: docs'
+    title:
+      - '/^docs(\(.+\))?(!)?:/i'
+  - label: 'type: refactor'
+    title:
+      - '/^refactor(\(.+\))?(!)?:/i'
+  - label: 'type: test'
+    title:
+      - '/^test(\(.+\))?(!)?:/i'
+  - label: 'type: chore'
+    title:
+      - '/^chore(\(.+\))?(!)?:/i'
+  - label: 'type: ci'
+    title:
+      - '/^ci(\(.+\))?(!)?:/i'
+  - label: 'type: revert'
+    title:
+      - '/^revert(\(.+\))?(!)?:/i'
+  - label: 'breaking-change'
+    title:
+      - '/^(feat|fix|docs|refactor|test|chore|ci|revert)(\([^)]*\))?!:/i'
+
+categories:
+  - title: '⚠️ Breaking Changes'
+    labels:
+      - 'breaking-change'
+  - title: '🚀 Features'
+    labels:
+      - 'type: feat'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'type: fix'
+  - title: '📚 Documentation'
+    labels:
+      - 'type: docs'
+  - title: '🔄 Refactoring'
+    labels:
+      - 'type: refactor'
+  - title: '✅ Tests'
+    labels:
+      - 'type: test'
+  - title: '🔧 Maintenance'
+    labels:
+      - 'type: chore'
+      - 'type: ci'
+      - 'type: revert'
+
+include-labels:
+  - 'type: feat'
+  - 'type: fix'
+  - 'type: docs'
+  - 'type: refactor'
+  - 'type: test'
+  - 'type: chore'
+  - 'type: ci'
+  - 'type: revert'
+  - 'breaking-change'
+
+exclude-labels:
+  - 'skip-changelog'
+  - 'internal'
+
 template: |
   ## Changes
 


### PR DESCRIPTION
## Summary
- `release-drafter.yml` had drifted from the shared org config used in `compono`
- Brings label taxonomy (`type: feat`, `type: fix`, etc.), categories, version-resolver, autolabeler regexes, and include/exclude-labels in line with the standard

## Changes
- Replaced `.github/release-drafter.yml` with the version matching `layered-craft/compono`

## Validation
- Diffed against `compono/.github/release-drafter.yml` — files now identical